### PR TITLE
Default to EFS when downloading zip files

### DIFF
--- a/bundles/common_resources/file_resources.go
+++ b/bundles/common_resources/file_resources.go
@@ -389,14 +389,17 @@ func MoveResource(resource Resource, destOwner string) *gz.ErrMsg {
 	return nil
 }
 
+// GetZipResource defines a function that allows getting a zip file from a local or remote location.
 type GetZipResource func(ctx context.Context, resource Resource, kind string, version int) (string, error)
 
+// GetZipLink allows to get the link to a zip file hosted in a remote location.
 func GetZipLink(storage storage.Storage) GetZipResource {
 	return func(ctx context.Context, resource Resource, kind string, version int) (string, error) {
 		return storage.Download(ctx, CastResourceToStorageResource(resource, uint64(version)))
 	}
 }
 
+// DownloadZipFile allows to serve a file directly, it returns the path to the zip file.
 func DownloadZipFile(ctx context.Context, resource Resource, kind string, version int) (string, error) {
 	l, _, em := GetZip(ctx, resource, kind, strconv.Itoa(version))
 	if em != nil {

--- a/bundles/common_resources/file_resources.go
+++ b/bundles/common_resources/file_resources.go
@@ -388,3 +388,19 @@ func MoveResource(resource Resource, destOwner string) *gz.ErrMsg {
 
 	return nil
 }
+
+type GetZipResource func(ctx context.Context, resource Resource, kind string, version int) (string, error)
+
+func GetZipLink(storage storage.Storage) GetZipResource {
+	return func(ctx context.Context, resource Resource, kind string, version int) (string, error) {
+		return storage.Download(ctx, CastResourceToStorageResource(resource, uint64(version)))
+	}
+}
+
+func DownloadZipFile(ctx context.Context, resource Resource, kind string, version int) (string, error) {
+	l, _, em := GetZip(ctx, resource, kind, strconv.Itoa(version))
+	if em != nil {
+		return "", em.BaseError
+	}
+	return *l, nil
+}

--- a/bundles/common_resources/file_resources.go
+++ b/bundles/common_resources/file_resources.go
@@ -392,14 +392,15 @@ func MoveResource(resource Resource, destOwner string) *gz.ErrMsg {
 // GetZipResource defines a function that allows getting a zip file from a local or remote location.
 type GetZipResource func(ctx context.Context, resource Resource, kind string, version int) (string, error)
 
-// GetZipLink allows to get the link to a zip file hosted in a remote location.
+// GetZipLink allows to get the link to a zip file.
 func GetZipLink(storage storage.Storage) GetZipResource {
 	return func(ctx context.Context, resource Resource, kind string, version int) (string, error) {
 		return storage.Download(ctx, CastResourceToStorageResource(resource, uint64(version)))
 	}
 }
 
-// DownloadZipFile allows to serve a file directly, it returns the path to the zip file.
+// DownloadZipFile allows to serve a file directly, it returns the path to the zip file from the EFS drive.
+// This method was added for backward compatibility with fuel clients that don't support redirects nor links to cloud providers.
 func DownloadZipFile(ctx context.Context, resource Resource, kind string, version int) (string, error) {
 	l, _, em := GetZip(ctx, resource, kind, strconv.Itoa(version))
 	if em != nil {

--- a/bundles/models/models_service.go
+++ b/bundles/models/models_service.go
@@ -448,7 +448,8 @@ func (ms *Service) GetFile(ctx context.Context, tx *gorm.DB, owner, name, path,
 // Optional argument "user" represents the user (if any) requesting the operation.
 // Returns the model, as well as a pointer to the zip's filepath and the
 // resolved version.
-func (ms *Service) DownloadZip(ctx context.Context, tx *gorm.DB, owner, modelName, version string, u *users.User, agent string, linkRequested bool) (*Model, *string, int, *gz.ErrMsg) {
+func (ms *Service) DownloadZip(ctx context.Context, tx *gorm.DB, owner, modelName, version string,
+	u *users.User, agent string, zipGetter res.GetZipResource) (*Model, *string, int, *gz.ErrMsg) {
 
 	model, em := ms.GetModel(tx, owner, modelName, u)
 	if em != nil {
@@ -473,21 +474,9 @@ func (ms *Service) DownloadZip(ctx context.Context, tx *gorm.DB, owner, modelNam
 		return nil, nil, 0, em
 	}
 
-	var link string
-	var err error
-
 	// If request link is enabled, the user will perform a subsequent request to download the resource from a cloud provider.
 	// Otherwise, it will expect Fuel to serve the file directly.
-	if linkRequested {
-		link, err = ms.Storage.Download(ctx, res.CastResourceToStorageResource(model, uint64(resolvedVersion)))
-	} else {
-		l, _, em := res.GetZip(ctx, model, models, version)
-		if em != nil {
-			err = em.BaseError
-		} else {
-			link = *l
-		}
-	}
+	link, err := zipGetter(ctx, model, models, resolvedVersion)
 	if err != nil {
 		return nil, nil, 0, gz.NewErrorMessageWithBase(gz.ErrorUnexpected, err)
 	}

--- a/bundles/worlds/worlds_service.go
+++ b/bundles/worlds/worlds_service.go
@@ -431,8 +431,7 @@ func (ws *Service) FileTree(ctx context.Context, tx *gorm.DB, owner, worldName,
 // Optional argument "user" represents the user (if any) requesting the operation.
 // Returns the world, as well as a pointer to the zip's filepath and the
 // resolved version.
-func (ws *Service) DownloadZip(ctx context.Context, tx *gorm.DB, owner, worldName,
-	version string, u *users.User, agent string) (*World, *string, int, *gz.ErrMsg) {
+func (ws *Service) DownloadZip(ctx context.Context, tx *gorm.DB, owner, worldName, version string, u *users.User, agent string, linkRequested bool) (*World, *string, int, *gz.ErrMsg) {
 
 	world, em := ws.GetWorld(tx, owner, worldName, u)
 	if em != nil {
@@ -455,11 +454,24 @@ func (ws *Service) DownloadZip(ctx context.Context, tx *gorm.DB, owner, worldNam
 	if em != nil {
 		return nil, nil, 0, em
 	}
-	link, err := ws.Storage.Download(ctx, res.CastResourceToStorageResource(world, uint64(resolvedVersion)))
+	var link string
+	var err error
+	// If request link is enabled, the user will perform a subsequent request to download the resource from a cloud provider.
+	// Otherwise, it will expect Fuel to serve the file directly.
+	if linkRequested {
+		link, err = ws.Storage.Download(ctx, res.CastResourceToStorageResource(world, uint64(resolvedVersion)))
+	} else {
+		l, _, em := res.GetZip(ctx, world, worlds, version)
+		if em != nil {
+			err = em.BaseError
+		} else {
+			link = *l
+		}
+	}
 	if err != nil {
 		return nil, nil, 0, gz.NewErrorMessageWithBase(gz.ErrorUnexpected, err)
 	}
-	return world, &link, resolvedVersion, em
+	return world, &link, resolvedVersion, nil
 }
 
 // UpdateWorld updates a world. The user argument is the requesting user. It

--- a/handler.go
+++ b/handler.go
@@ -566,7 +566,7 @@ func writeIgnResourceVersionHeader(w http.ResponseWriter, version int) {
 	w.Header().Set("X-Ign-Resource-Version", strconv.Itoa(version))
 }
 
-// serveFileOrLink returns a link to download the provided zip file from if linkRequested is set to true.
+// serveFileOrLink streams or returns a link to a resource depending on the criteria defined below.
 //
 //	If linkRequested is set to true:
 //		- it will write the URL as a plain text.

--- a/handler.go
+++ b/handler.go
@@ -561,33 +561,29 @@ func getOuterDir(files []*multipart.FileHeader, remove bool) (bool, string, *gz.
 	return remove, outDir, nil
 }
 
-// internal function that computes and sets the header X-Ign-Resource-Version.
-// TODO: this is a strong candidate to move to a models-related middleware.
-func writeIgnResourceVersionHeader(versionStr string,
-	w http.ResponseWriter, r *http.Request) (version string, err error) {
-	version = versionStr
-	w.Header().Set("X-Ign-Resource-Version", versionStr)
-	return
+// writeIgnResourceVersionHeader writes the ign resource version header into the given response.
+func writeIgnResourceVersionHeader(w http.ResponseWriter, version int) {
+	w.Header().Set("X-Ign-Resource-Version", strconv.Itoa(version))
 }
 
-// serveFileOrReturnLink returns the link where the client can download the zip file from when linkRequested is set to true.
+// serveFileOrLink returns the link where the client can download the zip file from when linkRequested is set to true.
 // If set to false, it will stream the file from the host machine directly to the client.
 //
 //	link must contain the URL where to download the resource from when linkRequested is set to true or,
 //	link must contain the path to the zip file when linkRequested is set to false.
-func serveFileOrReturnLink(w http.ResponseWriter, r *http.Request, linkRequested bool, link string, res res.Resource, version int) error {
+func serveFileOrLink(w http.ResponseWriter, r *http.Request, linkRequested bool, link string, res res.Resource, version int) error {
+	writeIgnResourceVersionHeader(w, version)
+
 	// If ?link=true, fuel will return a link to a cloud storage where the client can perform a subsequent request
-	// to download the resource. If ?link=false, it will serve the file directly to the client.
+	// to download the resource. If ?link=false or if it is not included, it will serve the file directly to the client.
 	if linkRequested {
-		// Set Content-Type
-		w.Header().Set("Content-Type", "text/plain")
-
-		// Return the link
-		w.WriteHeader(http.StatusOK)
-		_, err := w.Write([]byte(link))
-		return err
+		return serveLink(w, link)
 	}
+	return serveZipFile(w, r, res, version, link)
+}
 
+// serveZipFile serves a zip file located in path in the HTTP response.
+func serveZipFile(w http.ResponseWriter, r *http.Request, res res.Resource, version int, path string) error {
 	// Set zip headers
 	w.Header().Set("Content-Type", "application/zip")
 	zipFileName := fmt.Sprintf("model-%sv%d.zip", *res.GetUUID(), version)
@@ -595,12 +591,18 @@ func serveFileOrReturnLink(w http.ResponseWriter, r *http.Request, linkRequested
 	r.Header.Del("If-Modified-Since")
 	// Set zip response headers
 	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", zipFileName))
-	_, err := writeIgnResourceVersionHeader(strconv.Itoa(version), w, r)
-	if err != nil {
-		return err
-	}
-	http.ServeFile(w, r, link)
+	http.ServeFile(w, r, path)
 	return nil
+}
+
+// serveLink writes a link to a zip file into the HTTP response.
+func serveLink(w http.ResponseWriter, link string) error {
+	// Set Content-Type
+	w.Header().Set("Content-Type", "text/plain")
+	// Return the link
+	w.WriteHeader(http.StatusOK)
+	_, err := w.Write([]byte(link))
+	return err
 }
 
 // isLinkRequested returns true if a link was explicitly requested in the given HTTP request.

--- a/handler.go
+++ b/handler.go
@@ -567,10 +567,13 @@ func writeIgnResourceVersionHeader(w http.ResponseWriter, version int) {
 }
 
 // serveFileOrLink returns a link to download the provided zip file from if linkRequested is set to true.
-// If linkRequested is set to false, it will stream the file from the host machine directly to the client.
 //
-//	If linkRequested is set to true, link must contain the URL where to download the resource from when linkRequested is set to true or,
-//	if linkRequested is set to false, link must contain the path to the zip file when linkRequested is set to false.
+//	If linkRequested is set to true:
+//		- it will write the URL as a plain text.
+//		- link must contain the URL where to download the resource
+//	If linkRequested is set to false:
+//		- it will stream the file from the host machine directly to the client
+//		- link must contain the URL where to download the resource
 func serveFileOrLink(w http.ResponseWriter, r *http.Request, linkRequested bool, link string, res res.Resource, version int) error {
 	writeIgnResourceVersionHeader(w, version)
 

--- a/handler.go
+++ b/handler.go
@@ -566,11 +566,11 @@ func writeIgnResourceVersionHeader(w http.ResponseWriter, version int) {
 	w.Header().Set("X-Ign-Resource-Version", strconv.Itoa(version))
 }
 
-// serveFileOrLink returns a link to download the provided zip file from if `linkRequested` is set to true.
+// serveFileOrLink returns a link to download the provided zip file from if linkRequested is set to true.
 // If linkRequested is set to false, it will stream the file from the host machine directly to the client.
 //
-//	link must contain the URL where to download the resource from when linkRequested is set to true or,
-//	link must contain the path to the zip file when linkRequested is set to false.
+//	If linkRequested is set to true, link must contain the URL where to download the resource from when linkRequested is set to true or,
+//	if linkRequested is set to false, link must contain the path to the zip file when linkRequested is set to false.
 func serveFileOrLink(w http.ResponseWriter, r *http.Request, linkRequested bool, link string, res res.Resource, version int) error {
 	writeIgnResourceVersionHeader(w, version)
 
@@ -583,7 +583,8 @@ func serveFileOrLink(w http.ResponseWriter, r *http.Request, linkRequested bool,
 }
 
 // serveZipFile serves a zip file located in path in the HTTP response.
-// This function also writes the HTTP status code to 200 and sets the Content Type to application/zip.
+// This function also writes the HTTP status code to 200 and sets the Content Type to application/zip since
+// it's streaming the zip file directly to the client.
 func serveZipFile(w http.ResponseWriter, r *http.Request, res res.Resource, version int, path string) error {
 	// Set content type so clients can identify a zip file will be downloaded
 	w.Header().Set("Content-Type", "application/zip")
@@ -597,7 +598,8 @@ func serveZipFile(w http.ResponseWriter, r *http.Request, res res.Resource, vers
 }
 
 // serveLink writes a link to a zip file into the HTTP response.
-// This function also writes the HTTP status code to 200 and sets the Content Type to text/plain.
+// This function also writes the HTTP status code to 200 and sets the Content Type to text/plain given that
+// it's returning a link to the zip file.
 func serveLink(w http.ResponseWriter, link string) error {
 	// Set content type so clients can identify a link is being provided
 	w.Header().Set("Content-Type", "text/plain")

--- a/handler.go
+++ b/handler.go
@@ -583,6 +583,7 @@ func serveFileOrLink(w http.ResponseWriter, r *http.Request, linkRequested bool,
 }
 
 // serveZipFile serves a zip file located in path in the HTTP response.
+// This function also writes the HTTP status code to 200 and sets the Content Type to application/zip.
 func serveZipFile(w http.ResponseWriter, r *http.Request, res res.Resource, version int, path string) error {
 	// Set content type so clients can identify a zip file will be downloaded
 	w.Header().Set("Content-Type", "application/zip")
@@ -596,6 +597,7 @@ func serveZipFile(w http.ResponseWriter, r *http.Request, res res.Resource, vers
 }
 
 // serveLink writes a link to a zip file into the HTTP response.
+// This function also writes the HTTP status code to 200 and sets the Content Type to text/plain.
 func serveLink(w http.ResponseWriter, link string) error {
 	// Set content type so clients can identify a link is being provided
 	w.Header().Set("Content-Type", "text/plain")

--- a/handler.go
+++ b/handler.go
@@ -570,10 +570,10 @@ func writeIgnResourceVersionHeader(w http.ResponseWriter, version int) {
 //
 //	If linkRequested is set to true:
 //		- it will write the URL as a plain text.
-//		- link must contain the URL where to download the resource
+//		- link must contain the URL where to download the resource.
 //	If linkRequested is set to false:
-//		- it will stream the file from the host machine directly to the client
-//		- link must contain the URL where to download the resource
+//		- it will stream the file from the host machine directly to the client.
+//		- link must contain the path in the host machine where to stream the resource from.
 func serveFileOrLink(w http.ResponseWriter, r *http.Request, linkRequested bool, link string, res res.Resource, version int) error {
 	writeIgnResourceVersionHeader(w, version)
 

--- a/handler.go
+++ b/handler.go
@@ -574,8 +574,6 @@ func writeIgnResourceVersionHeader(w http.ResponseWriter, version int) {
 func serveFileOrLink(w http.ResponseWriter, r *http.Request, linkRequested bool, link string, res res.Resource, version int) error {
 	writeIgnResourceVersionHeader(w, version)
 
-	// If ?link=true, fuel will return a link to a cloud storage where the client can perform a subsequent request
-	// to download the resource. If ?link=false or if it is not included, it will serve the file directly to the client.
 	if linkRequested {
 		return serveLink(w, link)
 	}

--- a/handler.go
+++ b/handler.go
@@ -566,8 +566,8 @@ func writeIgnResourceVersionHeader(w http.ResponseWriter, version int) {
 	w.Header().Set("X-Ign-Resource-Version", strconv.Itoa(version))
 }
 
-// serveFileOrLink returns the link where the client can download the zip file from when linkRequested is set to true.
-// If set to false, it will stream the file from the host machine directly to the client.
+// serveFileOrLink returns a link to download the provided zip file from if `linkRequested` is set to true.
+// If linkRequested is set to false, it will stream the file from the host machine directly to the client.
 //
 //	link must contain the URL where to download the resource from when linkRequested is set to true or,
 //	link must contain the path to the zip file when linkRequested is set to false.
@@ -584,12 +584,12 @@ func serveFileOrLink(w http.ResponseWriter, r *http.Request, linkRequested bool,
 
 // serveZipFile serves a zip file located in path in the HTTP response.
 func serveZipFile(w http.ResponseWriter, r *http.Request, res res.Resource, version int, path string) error {
-	// Set zip headers
+	// Set content type so clients can identify a zip file will be downloaded
 	w.Header().Set("Content-Type", "application/zip")
-	zipFileName := fmt.Sprintf("model-%sv%d.zip", *res.GetUUID(), version)
 	// Remove request header to always serve fresh
 	r.Header.Del("If-Modified-Since")
 	// Set zip response headers
+	zipFileName := fmt.Sprintf("model-%sv%d.zip", *res.GetUUID(), version)
 	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", zipFileName))
 	http.ServeFile(w, r, path)
 	return nil
@@ -597,7 +597,7 @@ func serveZipFile(w http.ResponseWriter, r *http.Request, res res.Resource, vers
 
 // serveLink writes a link to a zip file into the HTTP response.
 func serveLink(w http.ResponseWriter, link string) error {
-	// Set Content-Type
+	// Set content type so clients can identify a link is being provided
 	w.Header().Set("Content-Type", "text/plain")
 	// Return the link
 	w.WriteHeader(http.StatusOK)

--- a/handler_file_resources.go
+++ b/handler_file_resources.go
@@ -13,7 +13,6 @@ import (
 	"github.com/jinzhu/gorm"
 	"net/http"
 	"path/filepath"
-	"strconv"
 	"time"
 )
 
@@ -48,10 +47,7 @@ func IndividualFileDownload(s getFileService, owner, name string, jwtUser *users
 		return nil, em
 	}
 
-	_, err := writeIgnResourceVersionHeader(strconv.Itoa(ver), w, r)
-	if err != nil {
-		return nil, gz.NewErrorMessageWithBase(gz.ErrorUnexpected, err)
-	}
+	writeIgnResourceVersionHeader(w, ver)
 
 	modtime := time.Now()
 	// Note: ServeContent should be always last line, after all headers were set.

--- a/handler_models.go
+++ b/handler_models.go
@@ -249,6 +249,8 @@ func ModelOwnerVersionZip(owner, name string, user *users.User, tx *gorm.DB,
 		return nil, gz.NewErrorMessageWithBase(gz.ErrorZipNotAvailable, err)
 	}
 
+	// If ?link=true, fuel will return a link to a cloud storage where the client can perform a subsequent request
+	// to download the resource. If ?link=false or if it is not included, it will serve the file directly to the client.
 	if err := serveFileOrLink(w, r, linkRequested, *link, model, ver); err != nil {
 		return nil, gz.NewErrorMessageWithBase(gz.ErrorZipNotAvailable, err)
 	}

--- a/handler_models.go
+++ b/handler_models.go
@@ -244,7 +244,7 @@ func ModelOwnerVersionZip(owner, name string, user *users.User, tx *gorm.DB,
 
 	// commit the DB transaction
 	// Note: we commit the TX here on purpose, to be able to detect DB errors
-	// before writing "data" to ResponseWriter. Once you write data (not headers)
+	// before writing "data" to ResponseWriter.
 	if err := tx.Commit().Error; err != nil {
 		return nil, gz.NewErrorMessageWithBase(gz.ErrorZipNotAvailable, err)
 	}

--- a/handler_worlds.go
+++ b/handler_worlds.go
@@ -264,6 +264,8 @@ func WorldZip(owner, name string, user *users.User, tx *gorm.DB,
 		return nil, gz.NewErrorMessageWithBase(gz.ErrorZipNotAvailable, err)
 	}
 
+	// If ?link=true, fuel will return a link to a cloud storage where the client can perform a subsequent request
+	// to download the resource. If ?link=false or if it is not included, it will serve the file directly to the client.
 	if err := serveFileOrLink(w, r, linkRequested, *link, world, ver); err != nil {
 		return nil, gz.NewErrorMessageWithBase(gz.ErrorZipNotAvailable, err)
 	}

--- a/handler_worlds.go
+++ b/handler_worlds.go
@@ -264,8 +264,8 @@ func WorldZip(owner, name string, user *users.User, tx *gorm.DB,
 		return nil, gz.NewErrorMessageWithBase(gz.ErrorZipNotAvailable, err)
 	}
 
-	// If ?link=true, fuel will return a link to a cloud storage where the client can perform a subsequent request
-	// to download the resource. If ?link=false or if it is not included, it will serve the file directly to the client.
+	// If a link was requested, fuel will return a link to a cloud storage where the client can perform a subsequent request
+	// to download the resource. If a link was not requested or if it is not included, it will serve the file directly to the client.
 	if err := serveFileOrLink(w, r, linkRequested, *link, world, ver); err != nil {
 		return nil, gz.NewErrorMessageWithBase(gz.ErrorZipNotAvailable, err)
 	}

--- a/handler_worlds.go
+++ b/handler_worlds.go
@@ -259,7 +259,7 @@ func WorldZip(owner, name string, user *users.User, tx *gorm.DB,
 
 	// commit the DB transaction
 	// Note: we commit the TX here on purpose, to be able to detect DB errors
-	// before writing "data" to ResponseWriter. Once you write data (not headers)
+	// before writing "data" to ResponseWriter.
 	if err := tx.Commit().Error; err != nil {
 		return nil, gz.NewErrorMessageWithBase(gz.ErrorZipNotAvailable, err)
 	}

--- a/handler_worlds.go
+++ b/handler_worlds.go
@@ -3,14 +3,13 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	res "github.com/gazebo-web/fuel-server/bundles/common_resources"
 	"github.com/gazebo-web/fuel-server/globals"
 	"github.com/gazebo-web/gz-go/v7"
 	"log"
 	"mime/multipart"
 	"net/http"
 	"os"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/gazebo-web/fuel-server/bundles/collections"
@@ -106,10 +105,7 @@ func WorldFileTree(owner, name string, user *users.User, tx *gorm.DB,
 		return nil, em
 	}
 
-	_, err := writeIgnResourceVersionHeader(strconv.Itoa(int(*worldProto.Version)), w, r)
-	if err != nil {
-		return nil, gz.NewErrorMessageWithBase(gz.ErrorUnexpected, err)
-	}
+	writeIgnResourceVersionHeader(w, int(worldProto.GetVersion()))
 
 	return worldProto, em
 }
@@ -128,10 +124,7 @@ func WorldIndex(owner, name string, user *users.User, tx *gorm.DB,
 		return nil, em
 	}
 
-	_, err := writeIgnResourceVersionHeader(strconv.Itoa(int(*fuelWorld.Version)), w, r)
-	if err != nil {
-		return nil, gz.NewErrorMessageWithBase(gz.ErrorUnexpected, err)
-	}
+	writeIgnResourceVersionHeader(w, int(fuelWorld.GetVersion()))
 
 	return fuelWorld, nil
 }
@@ -251,9 +244,15 @@ func WorldZip(owner, name string, user *users.User, tx *gorm.DB,
 		version = ""
 	}
 
-	linkRequested := strings.ToLower(r.URL.Query().Get("link")) == "true"
+	svc := &worlds.Service{Storage: globals.Storage}
 
-	world, link, ver, em := (&worlds.Service{Storage: globals.Storage}).DownloadZip(r.Context(), tx, owner, name, version, user, r.UserAgent(), false)
+	zipGetter := res.DownloadZipFile
+	linkRequested := isLinkRequested(r)
+	if linkRequested {
+		zipGetter = res.GetZipLink(svc.Storage)
+	}
+
+	world, link, ver, em := svc.DownloadZip(r.Context(), tx, owner, name, version, user, r.UserAgent(), zipGetter)
 	if em != nil {
 		return nil, em
 	}
@@ -265,7 +264,7 @@ func WorldZip(owner, name string, user *users.User, tx *gorm.DB,
 		return nil, gz.NewErrorMessageWithBase(gz.ErrorZipNotAvailable, err)
 	}
 
-	if err := serveFileOrReturnLink(w, r, linkRequested, *link, world, ver); err != nil {
+	if err := serveFileOrLink(w, r, linkRequested, *link, world, ver); err != nil {
 		return nil, gz.NewErrorMessageWithBase(gz.ErrorZipNotAvailable, err)
 	}
 	return nil, nil

--- a/router_models_test.go
+++ b/router_models_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"archive/zip"
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"github.com/gazebo-web/gz-go/v7"
@@ -648,6 +650,8 @@ type modelDownloadAsZipTest struct {
 	name  string
 	// the expected returned model version, in the X-Ign-Resource-Version header. Must be a number
 	ignVersionHeader int
+	// a map containing files that should be present in the returned zip. Eg. {"model.sdf":true, "model.config":true}
+	expZipFiles map[string]bool
 	// expected downloads count for this zip (after downloading it). Note: this makes the test cases to be dependent among them.
 	expDownloads int
 	// expected username of the user that performed this download. Can be empty.
@@ -688,40 +692,49 @@ func TestGetModelAsZip(t *testing.T) {
 
 	// Get the created model
 	model := getOwnerModelFromDb(t, testUser, "model1")
+	files := map[string]bool{"thumbnails/": true, "thumbnails/model.sdf": true, "model.config": true}
 
 	// Now check we can get the model as zip file using different uris
 	modelDownloadAsZipTestsData := []modelDownloadAsZipTest{
-		{uriTest{"/owner/models/name style", modelURL(testUser, *model.Name, ""), &testJWT{jwt: &myJWT}, nil, false}, testUser, *model.Name, 1, 1, testUser},
-		{uriTest{"with explicit model version", modelURL(testUser, *model.Name, "1"), &testJWT{jwt: &myJWT}, nil, false}, testUser, *model.Name, 1, 2, testUser},
-		{uriTest{"with no JWT", modelURL(testUser, *model.Name, "tip"), nil, nil, false}, testUser, *model.Name, 1, 3, ""},
-		{uriTest{"invalid (negative) version", modelURL(testUser, *model.Name, "-4"), nil, gz.NewErrorMessage(gz.ErrorFormInvalidValue), false}, testUser, *model.Name, 1, 3, ""},
-		{uriTest{"invalid (alpha) version", modelURL(testUser, *model.Name, "a"), nil, gz.NewErrorMessage(gz.ErrorFormInvalidValue), false}, testUser, *model.Name, 1, 3, ""},
-		{uriTest{"0 version", modelURL(testUser, *model.Name, "0"), nil, gz.NewErrorMessage(gz.ErrorFormInvalidValue), false}, testUser, *model.Name, 1, 3, ""},
-		{uriTest{"version not found", modelURL(testUser, *model.Name, "5"), nil, gz.NewErrorMessage(gz.ErrorVersionNotFound), false}, testUser, *model.Name, 1, 3, ""},
-		{uriTest{"get private org model by org owner", modelURL(testOrg, "private", ""), &testJWT{jwt: &myJWT}, nil, false}, testOrg, "private", 1, 1, testUser},
-		{uriTest{"get private org model by admin", modelURL(testOrg, "private", ""), newJWT(jwt4), nil, false}, testOrg, "private", 1, 2, user4},
-		{uriTest{"get private org model by member", modelURL(testOrg, "private", ""), newJWT(jwt2), nil, false}, testOrg, "private", 1, 3, user2},
-		{uriTest{"get private org model by non member", modelURL(testOrg, "private", ""), newJWT(jwt3), gz.NewErrorMessage(gz.ErrorUnauthorized), false}, testOrg, "", 1, 2, ""},
-		{uriTest{"get private org model with no jwt", modelURL(testOrg, "private", ""), nil, gz.NewErrorMessage(gz.ErrorUnauthorized), false}, testOrg, "", 1, 2, ""},
-		{uriTest{"get private user model with no jwt", modelURL(testUser, "user_private", ""), nil, gz.NewErrorMessage(gz.ErrorUnauthorized), false}, testOrg, "", 1, 2, ""},
-		{uriTest{"get private user model with another jwt", modelURL(testUser, "user_private", ""), newJWT(jwt3), gz.NewErrorMessage(gz.ErrorUnauthorized), false}, testOrg, "", 1, 2, ""},
+		{uriTest{"/owner/models/name style", modelURL(testUser, *model.Name, ""), &testJWT{jwt: &myJWT}, nil, false}, testUser, *model.Name, 1, files, 1, testUser},
+		{uriTest{"with explicit model version", modelURL(testUser, *model.Name, "1"), &testJWT{jwt: &myJWT}, nil, false}, testUser, *model.Name, 1, files, 2, testUser},
+		{uriTest{"with no JWT", modelURL(testUser, *model.Name, "tip"), nil, nil, false}, testUser, *model.Name, 1, files, 3, ""},
+		{uriTest{"invalid (negative) version", modelURL(testUser, *model.Name, "-4"), nil, gz.NewErrorMessage(gz.ErrorFormInvalidValue), false}, testUser, *model.Name, 1, files, 3, ""},
+		{uriTest{"invalid (alpha) version", modelURL(testUser, *model.Name, "a"), nil, gz.NewErrorMessage(gz.ErrorFormInvalidValue), false}, testUser, *model.Name, 1, files, 3, ""},
+		{uriTest{"0 version", modelURL(testUser, *model.Name, "0"), nil, gz.NewErrorMessage(gz.ErrorFormInvalidValue), false}, testUser, *model.Name, 1, files, 3, ""},
+		{uriTest{"version not found", modelURL(testUser, *model.Name, "5"), nil, gz.NewErrorMessage(gz.ErrorVersionNotFound), false}, testUser, *model.Name, 1, files, 3, ""},
+		{uriTest{"get private org model by org owner", modelURL(testOrg, "private", ""), &testJWT{jwt: &myJWT}, nil, false}, testOrg, "private", 1, files, 1, testUser},
+		{uriTest{"get private org model by admin", modelURL(testOrg, "private", ""), newJWT(jwt4), nil, false}, testOrg, "private", 1, files, 2, user4},
+		{uriTest{"get private org model by member", modelURL(testOrg, "private", ""), newJWT(jwt2), nil, false}, testOrg, "private", 1, files, 3, user2},
+		{uriTest{"get private org model by non member", modelURL(testOrg, "private", ""), newJWT(jwt3), gz.NewErrorMessage(gz.ErrorUnauthorized), false}, testOrg, "", 1, files, 2, ""},
+		{uriTest{"get private org model with no jwt", modelURL(testOrg, "private", ""), nil, gz.NewErrorMessage(gz.ErrorUnauthorized), false}, testOrg, "", 1, files, 2, ""},
+		{uriTest{"get private user model with no jwt", modelURL(testUser, "user_private", ""), nil, gz.NewErrorMessage(gz.ErrorUnauthorized), false}, testOrg, "", 1, files, 2, ""},
+		{uriTest{"get private user model with another jwt", modelURL(testUser, "user_private", ""), newJWT(jwt3), gz.NewErrorMessage(gz.ErrorUnauthorized), false}, testOrg, "", 1, files, 2, ""},
 	}
 
 	for _, test := range modelDownloadAsZipTestsData {
 		t.Run(test.testDesc, func(t *testing.T) {
 			jwt := getJWTToken(t, test.jwtGen)
 			expEm, expCt := errMsgAndContentType(test.expErrMsg, ctZip)
-			expStatus := http.StatusFound
+			expStatus := expEm.StatusCode
 			reqArgs := gztest.RequestArgs{Method: "GET", Route: test.URL + ".zip", Body: nil, SignedToken: jwt}
 			resp := gztest.AssertRouteMultipleArgsStruct(reqArgs, expStatus, expCt, t)
 			bslice := resp.BodyAsBytes
 			assert.Equal(t, expStatus, resp.RespRecorder.Code)
-			if !test.ignoreErrorBody {
+			if expStatus != http.StatusOK && !test.ignoreErrorBody {
 				gztest.AssertBackendErrorCode(t.Name(), bslice, expEm.ErrCode, t)
-			} else {
+			} else if expStatus == http.StatusOK {
 				assert.True(t, resp.Ok, "Model Zip Download request didn't succeed")
 				ensureIgnResourceVersionHeader(resp.RespRecorder, test.ignVersionHeader, t)
+				zSize := len(*bslice)
+				zipReader, err := zip.NewReader(bytes.NewReader(*bslice), int64(zSize))
+				assert.NoError(t, err, "Unable to read zip response")
+				assert.NotEmpty(t, zipReader.File, "Got zip file did not have any files")
+				for _, f := range zipReader.File {
+					assert.True(t, test.expZipFiles[f.Name], "Got Zip file not included in expected files: %s", f.Name)
+				}
 				m := getOwnerModelFromDb(t, test.owner, test.name)
+				assert.Equal(t, zSize, m.Filesize, "Zip file size (%d) is not equal to Model's Filesize field (%d)", zSize, m.Filesize)
 				assert.Equal(t, test.expDownloads, m.Downloads, "Downloads counter should be %d. Got: %d", test.expDownloads, m.Downloads)
 				mds := getModelDownloadsFromDb(t, test.owner, test.name)
 				assert.Len(t, *mds, test.expDownloads, "Model Downloads length should be %d. Got %d", test.expDownloads, len(*mds))


### PR DESCRIPTION
This PR defaults downloads to EFS. Downloads from cloud providers can now be requested by using the `link` query param set to true.

This change was made in order to extend support for old clients that don't support redirects nor subsequent requests.