### PR TITLE
Optimize like and download queries for models and worlds

### DIFF
--- a/bundles/models/models_service.go
+++ b/bundles/models/models_service.go
@@ -304,35 +304,32 @@ func (ms *Service) getModelLike(tx *gorm.DB, model *Model, user *users.User) (*M
 }
 
 // CreateModelLike creates a ModelLike.
-// Returns the created modelLike, the current count of likes, or an gz.errMsg.
-func (ms *Service) CreateModelLike(tx *gorm.DB, owner, modelName string,
-	user *users.User) (*ModelLike, int, *gz.ErrMsg) {
-
+// Returns the created modelLike, or a gz.errMsg.
+func (ms *Service) CreateModelLike(tx *gorm.DB, owner, modelName string, user *users.User) (*ModelLike, *gz.ErrMsg) {
 	if user == nil {
-		return nil, 0, gz.NewErrorMessage(gz.ErrorAuthNoUser)
+		return nil, gz.NewErrorMessage(gz.ErrorAuthNoUser)
 	}
 
 	model, em := ms.GetModel(tx, owner, modelName, user)
 	if em != nil {
-		return nil, 0, em
+		return nil, em
 	}
 
 	// Register the like.
 	modelLike := ModelLike{UserID: &user.ID, ModelID: &model.ID}
 	if err := tx.Create(&modelLike).Error; err != nil {
-		return nil, 0, gz.NewErrorMessageWithBase(gz.ErrorDbSave, err)
+		return nil, gz.NewErrorMessageWithBase(gz.ErrorDbSave, err)
 	}
 	// Update the number of likes of the model.
-	count, errorMsg := ms.updateLikesCounter(tx, model)
+	errorMsg := ms.increaseLikeCounter(tx, model)
 	if errorMsg != nil {
-		return nil, 0, errorMsg
+		return nil, errorMsg
 	}
-	return &modelLike, count, nil
+	return &modelLike, nil
 }
 
 // CreateModelReport creates a ModelReport
 func (ms *Service) CreateModelReport(tx *gorm.DB, owner, modelName, reason string) (*ModelReport, *gz.ErrMsg) {
-
 	model, err := GetModelByName(tx, modelName, owner)
 
 	if err != nil {
@@ -354,30 +351,36 @@ func (ms *Service) CreateModelReport(tx *gorm.DB, owner, modelName, reason strin
 }
 
 // RemoveModelLike removes a ModelLike.
-// Returns the removed modelLike, the current count of likes, or an gz.errMsg.
-func (ms *Service) RemoveModelLike(tx *gorm.DB, owner, modelName string,
-	user *users.User) (*ModelLike, int, *gz.ErrMsg) {
-
+// Returns the removed modelLike or a gz.errMsg.
+func (ms *Service) RemoveModelLike(tx *gorm.DB, owner, modelName string, user *users.User) (*ModelLike, *gz.ErrMsg) {
 	if user == nil {
-		return nil, 0, gz.NewErrorMessage(gz.ErrorAuthNoUser)
+		return nil, gz.NewErrorMessage(gz.ErrorAuthNoUser)
 	}
 
 	model, em := ms.GetModel(tx, owner, modelName, user)
 	if em != nil {
-		return nil, 0, em
+		return nil, em
 	}
 
 	// Unlike the model.
 	var modelLike ModelLike
 	if err := tx.Where("user_id = ? AND model_id = ?", &user.ID, &model.ID).Delete(&modelLike).Error; err != nil {
-		return nil, 0, gz.NewErrorMessageWithBase(gz.ErrorDbDelete, err)
+		return nil, gz.NewErrorMessageWithBase(gz.ErrorDbDelete, err)
 	}
 	// Update the number of likes of the model.
-	count, errorMsg := ms.updateLikesCounter(tx, model)
+	errorMsg := ms.decreaseLikeCounter(tx, model)
 	if errorMsg != nil {
-		return nil, 0, errorMsg
+		return nil, errorMsg
 	}
-	return &modelLike, count, nil
+	return &modelLike, nil
+}
+
+// applyExpression updates a model using SQL expression that can perform operations on referred values.
+func (ms *Service) applyExpression(tx *gorm.DB, model *Model, field string, expr *gorm.SqlExpr) *gz.ErrMsg {
+	if err := tx.Model(model).Update(field, expr).Error; err != nil {
+		return gz.NewErrorMessageWithBase(gz.ErrorDbSave, err)
+	}
+	return nil
 }
 
 // ComputeAllCounters is an initialization function that iterates
@@ -389,18 +392,20 @@ func (ms *Service) ComputeAllCounters(tx *gorm.DB) *gz.ErrMsg {
 		return gz.NewErrorMessageWithBase(gz.ErrorNoDatabase, err)
 	}
 	for _, model := range modelList {
-		if _, em := ms.updateLikesCounter(tx, &model); em != nil {
+		if _, em := ms.computeLikeCounter(tx, &model); em != nil {
 			return em
 		}
-		if _, em := ms.updateDownloadsCounter(tx, &model); em != nil {
+		if _, em := ms.computeDownloadCounter(tx, &model); em != nil {
 			return em
 		}
 	}
 	return nil
 }
 
-// updateLikesCounter counts the number of likes and updates the model accordingly.
-func (ms *Service) updateLikesCounter(tx *gorm.DB, model *Model) (int, *gz.ErrMsg) {
+// computeLikeCounter counts the number of likes and updates the model accordingly.
+// This query is VERY EXPENSIVE. Only use to set the state if it doesn't exist.
+// For all other purposes, the use of increase/decreaseLikeCounter is recommended.
+func (ms *Service) computeLikeCounter(tx *gorm.DB, model *Model) (int, *gz.ErrMsg) {
 	var counter int
 	// Count the number of likes of the model.
 	if err := tx.Model(&ModelLike{}).Where("model_id = ?", model.ID).Count(&counter).Error; err != nil {
@@ -415,9 +420,20 @@ func (ms *Service) updateLikesCounter(tx *gorm.DB, model *Model) (int, *gz.ErrMs
 	return counter, nil
 }
 
-// updateDownloadsCounter counts the number of downloads and updates the
-// model accordingly.
-func (ms *Service) updateDownloadsCounter(tx *gorm.DB, model *Model) (int, *gz.ErrMsg) {
+// increaseLikeCounter increases the current like count of a model by 1.
+func (ms *Service) increaseLikeCounter(tx *gorm.DB, model *Model) *gz.ErrMsg {
+	return ms.applyExpression(tx, model, "likes", gorm.Expr("likes + 1"))
+}
+
+// decreaseLikeCounter decreases the current like count of a model by 1.
+func (ms *Service) decreaseLikeCounter(tx *gorm.DB, model *Model) *gz.ErrMsg {
+	return ms.applyExpression(tx, model, "likes", gorm.Expr("likes - 1"))
+}
+
+// computeDownloadCounter counts the number of downloads and updates the model accordingly.
+// This query is VERY EXPENSIVE. Only use to set the state if it doesn't exist.
+// For all other purposes, the use of increaseDownloadCounter is recommended.
+func (ms *Service) computeDownloadCounter(tx *gorm.DB, model *Model) (int, *gz.ErrMsg) {
 	// Count the number of downloads of the model.
 	var count int
 	if err := tx.Model(&ModelDownload{}).Where("model_id = ?", model.ID).Count(&count).Error; err != nil {
@@ -427,6 +443,11 @@ func (ms *Service) updateDownloadsCounter(tx *gorm.DB, model *Model) (int, *gz.E
 		return 0, gz.NewErrorMessageWithBase(gz.ErrorDbSave, err)
 	}
 	return count, nil
+}
+
+// increaseDownloadCounter increases the current download count of a model by 1.
+func (ms *Service) increaseDownloadCounter(tx *gorm.DB, model *Model) *gz.ErrMsg {
+	return ms.applyExpression(tx, model, "downloads", gorm.Expr("downloads + 1"))
 }
 
 // GetFile returns the contents (bytes) of a model file. Model version is considered.
@@ -464,7 +485,7 @@ func (ms *Service) DownloadZip(ctx context.Context, tx *gorm.DB, owner, modelNam
 		return nil, nil, 0, gz.NewErrorMessageWithBase(gz.ErrorDbSave, err)
 	}
 	// Update the number of downloads of the model.
-	_, errorMsg := ms.updateDownloadsCounter(tx, model)
+	errorMsg := ms.increaseDownloadCounter(tx, model)
 	if errorMsg != nil {
 		return nil, nil, 0, errorMsg
 	}

--- a/bundles/worlds/worlds_service.go
+++ b/bundles/worlds/worlds_service.go
@@ -273,30 +273,28 @@ func (ws *Service) getWorldLike(tx *gorm.DB, world *World, user *users.User) (*W
 }
 
 // CreateWorldLike creates a WorldLike.
-// Returns the created worldLike, the current count of likes, or an gz.errMsg.
-func (ws *Service) CreateWorldLike(tx *gorm.DB, owner, worldName string,
-	user *users.User) (*WorldLike, int, *gz.ErrMsg) {
-
+// Returns the created worldLike, or a gz.errMsg.
+func (ws *Service) CreateWorldLike(tx *gorm.DB, owner, worldName string, user *users.User) (*WorldLike, *gz.ErrMsg) {
 	if user == nil {
-		return nil, 0, gz.NewErrorMessage(gz.ErrorAuthNoUser)
+		return nil, gz.NewErrorMessage(gz.ErrorAuthNoUser)
 	}
 
 	world, em := ws.GetWorld(tx, owner, worldName, user)
 	if em != nil {
-		return nil, 0, em
+		return nil, em
 	}
 
 	// Register the like.
 	worldLike := WorldLike{UserID: &user.ID, WorldID: &world.ID}
 	if err := tx.Create(&worldLike).Error; err != nil {
-		return nil, 0, gz.NewErrorMessageWithBase(gz.ErrorDbSave, err)
+		return nil, gz.NewErrorMessageWithBase(gz.ErrorDbSave, err)
 	}
 	// Update the number of likes of the world.
-	count, errorMsg := ws.updateLikeCounter(tx, world)
+	errorMsg := ws.increaseLikeCounter(tx, world)
 	if errorMsg != nil {
-		return nil, 0, errorMsg
+		return nil, errorMsg
 	}
-	return &worldLike, count, nil
+	return &worldLike, nil
 }
 
 // CreateWorldReport creates a WorldReport
@@ -323,62 +321,37 @@ func (ws *Service) CreateWorldReport(tx *gorm.DB, owner, worldName, reason strin
 }
 
 // RemoveWorldLike removes a worldLike.
-// Returns the removed worldLike, the current count of likes, or an gz.errMsg.
-func (ws *Service) RemoveWorldLike(tx *gorm.DB, owner, worldName string,
-	user *users.User) (*WorldLike, int, *gz.ErrMsg) {
+// Returns the removed worldLike or a gz.errMsg.
+func (ws *Service) RemoveWorldLike(tx *gorm.DB, owner, worldName string, user *users.User) (*WorldLike, *gz.ErrMsg) {
 
 	if user == nil {
-		return nil, 0, gz.NewErrorMessage(gz.ErrorAuthNoUser)
+		return nil, gz.NewErrorMessage(gz.ErrorAuthNoUser)
 	}
 
 	world, em := ws.GetWorld(tx, owner, worldName, user)
 	if em != nil {
-		return nil, 0, em
+		return nil, em
 	}
 
 	// Unlike the world.
 	var worldLike WorldLike
 	if err := tx.Where("user_id = ? AND world_id = ?", &user.ID, &world.ID).Delete(&worldLike).Error; err != nil {
-		return nil, 0, gz.NewErrorMessageWithBase(gz.ErrorDbDelete, err)
+		return nil, gz.NewErrorMessageWithBase(gz.ErrorDbDelete, err)
 	}
 	// Update the number of likes of the world.
-	count, errorMsg := ws.updateLikeCounter(tx, world)
+	errorMsg := ws.decreaseLikeCounter(tx, world)
 	if errorMsg != nil {
-		return nil, 0, errorMsg
+		return nil, errorMsg
 	}
-	return &worldLike, count, nil
+	return &worldLike, nil
 }
 
-// updateLikeCounter counts the number of likes and updates the world accordingly.
-func (ws *Service) updateLikeCounter(tx *gorm.DB, world *World) (int, *gz.ErrMsg) {
-	var counter int
-	// Count the number of likes of the world.
-	if err := tx.Model(&WorldLike{}).Where("world_id = ?", world.ID).Count(&counter).Error; err != nil {
-		// Note: This is not currently covered by the tests.
-		return 0, gz.NewErrorMessageWithBase(gz.ErrorDbSave, err)
+// applyExpression updates a world using SQL expression that can perform operations on referred values.
+func (ws *Service) applyExpression(tx *gorm.DB, world *World, field string, expr *gorm.SqlExpr) *gz.ErrMsg {
+	if err := tx.Model(world).Update(field, expr).Error; err != nil {
+		return gz.NewErrorMessageWithBase(gz.ErrorDbSave, err)
 	}
-	// Update the number of likes of the world.
-	if err := tx.Model(world).Update("likes", counter).Error; err != nil {
-		// Note: This is not currently covered by the tests.
-		return 0, gz.NewErrorMessageWithBase(gz.ErrorDbSave, err)
-	}
-	return counter, nil
-}
-
-// updateDownloadsCounter counts the number of downloads and updates the world
-// accordingly.
-func (ws *Service) updateDownloadsCounter(tx *gorm.DB, world *World) (int, *gz.ErrMsg) {
-	var count int
-	// Count the number of downloads of the world.
-	if err := tx.Model(&WorldDownload{}).Where("world_id = ?", world.ID).Count(&count).Error; err != nil {
-		// Note: This is not currently covered by the tests.
-		return 0, gz.NewErrorMessageWithBase(gz.ErrorDbSave, err)
-	}
-	// Update the number of downloads of the world.
-	if err := tx.Model(world).Update("Downloads", count).Error; err != nil {
-		return 0, gz.NewErrorMessageWithBase(gz.ErrorDbSave, err)
-	}
-	return count, nil
+	return nil
 }
 
 // ComputeAllCounters is an initialization function that iterates
@@ -390,14 +363,64 @@ func (ws *Service) ComputeAllCounters(tx *gorm.DB) *gz.ErrMsg {
 		return gz.NewErrorMessageWithBase(gz.ErrorNoDatabase, err)
 	}
 	for _, w := range worldList {
-		if _, em := ws.updateLikeCounter(tx, &w); em != nil {
+		if em := ws.computeLikeCounter(tx, &w); em != nil {
 			return em
 		}
-		if _, em := ws.updateDownloadsCounter(tx, &w); em != nil {
+		if em := ws.computeDownloadCounter(tx, &w); em != nil {
 			return em
 		}
 	}
 	return nil
+}
+
+// computeLikeCounter counts the number of likes and updates the world accordingly.
+// This query is VERY EXPENSIVE. Only use to set the state if it doesn't exist.
+// For all other purposes, the use of increase/decreaseLikeCounter is recommended.
+func (ws *Service) computeLikeCounter(tx *gorm.DB, world *World) *gz.ErrMsg {
+	// Count the number of likes of the world.
+	var counter int
+	if err := tx.Model(&WorldLike{}).Where("world_id = ?", world.ID).Count(&counter).Error; err != nil {
+		// Note: This is not currently covered by the tests.
+		return gz.NewErrorMessageWithBase(gz.ErrorDbSave, err)
+	}
+	// Update the number of likes of the world.
+	if err := tx.Model(world).Update("likes", counter).Error; err != nil {
+		// Note: This is not currently covered by the tests.
+		return gz.NewErrorMessageWithBase(gz.ErrorDbSave, err)
+	}
+	return nil
+}
+
+// increaseLikeCounter increases the current like count of a world by 1.
+func (ws *Service) increaseLikeCounter(tx *gorm.DB, world *World) *gz.ErrMsg {
+	return ws.applyExpression(tx, world, "likes", gorm.Expr("likes + 1"))
+}
+
+// decreaseLikeCounter decreases the current like count of a world by 1.
+func (ws *Service) decreaseLikeCounter(tx *gorm.DB, world *World) *gz.ErrMsg {
+	return ws.applyExpression(tx, world, "likes", gorm.Expr("likes - 1"))
+}
+
+// computeDownloadCounter counts the number of downloads and updates the world accordingly.
+// This query is VERY EXPENSIVE. Only use to set the state if it doesn't exist.
+// For all other purposes, the use of increaseDownloadCounter is recommended.
+func (ws *Service) computeDownloadCounter(tx *gorm.DB, world *World) *gz.ErrMsg {
+	// Count the number of downloads of the world.
+	var count int
+	if err := tx.Model(&WorldDownload{}).Where("world_id = ?", world.ID).Count(&count).Error; err != nil {
+		// Note: This is not currently covered by the tests.
+		return gz.NewErrorMessageWithBase(gz.ErrorDbSave, err)
+	}
+	// Update the number of downloads of the world.
+	if err := tx.Model(world).Update("Downloads", count).Error; err != nil {
+		return gz.NewErrorMessageWithBase(gz.ErrorDbSave, err)
+	}
+	return nil
+}
+
+// increaseDownloadCounter increases the current download count of a world by 1.
+func (ws *Service) increaseDownloadCounter(tx *gorm.DB, world *World) *gz.ErrMsg {
+	return ws.applyExpression(tx, world, "downloads", gorm.Expr("downloads + 1"))
 }
 
 // GetFile returns the contents (bytes) of a world file. World version is considered.
@@ -447,7 +470,7 @@ func (ws *Service) DownloadZip(ctx context.Context, tx *gorm.DB, owner, worldNam
 		return nil, nil, 0, gz.NewErrorMessageWithBase(gz.ErrorDbSave, err)
 	}
 	// Update the number of downloads of the world.
-	_, errorMsg := ws.updateDownloadsCounter(tx, world)
+	errorMsg := ws.increaseDownloadCounter(tx, world)
 	if errorMsg != nil {
 		return nil, nil, 0, errorMsg
 	}

--- a/handler_models.go
+++ b/handler_models.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"github.com/gazebo-web/fuel-server/bundles/category"
 	"github.com/gazebo-web/fuel-server/bundles/collections"
 	res "github.com/gazebo-web/fuel-server/bundles/common_resources"
@@ -160,7 +159,7 @@ func ModelOwnerRemove(owner, modelName string, user *users.User, tx *gorm.DB,
 func ModelOwnerLikeCreate(owner, name string, user *users.User, tx *gorm.DB,
 	w http.ResponseWriter, r *http.Request) (interface{}, *gz.ErrMsg) {
 
-	_, count, em := (&models.Service{Storage: globals.Storage}).CreateModelLike(tx, owner, name, user)
+	_, em := (&models.Service{Storage: globals.Storage}).CreateModelLike(tx, owner, name, user)
 	if em != nil {
 		return nil, em
 	}
@@ -173,7 +172,6 @@ func ModelOwnerLikeCreate(owner, name string, user *users.User, tx *gorm.DB,
 		return nil, gz.NewErrorMessageWithBase(gz.ErrorDbSave, err)
 	}
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-	fmt.Fprint(w, count)
 	return nil, nil
 }
 
@@ -185,7 +183,7 @@ func ModelOwnerLikeCreate(owner, name string, user *users.User, tx *gorm.DB,
 func ModelOwnerLikeRemove(owner, name string, user *users.User, tx *gorm.DB,
 	w http.ResponseWriter, r *http.Request) (interface{}, *gz.ErrMsg) {
 
-	_, count, em := (&models.Service{Storage: globals.Storage}).RemoveModelLike(tx, owner, name, user)
+	_, em := (&models.Service{Storage: globals.Storage}).RemoveModelLike(tx, owner, name, user)
 	if em != nil {
 		return nil, em
 	}
@@ -199,7 +197,6 @@ func ModelOwnerLikeRemove(owner, name string, user *users.User, tx *gorm.DB,
 	}
 
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-	fmt.Fprint(w, count)
 	return nil, nil
 }
 

--- a/handler_worlds.go
+++ b/handler_worlds.go
@@ -173,7 +173,7 @@ func WorldRemove(owner, name string, user *users.User, tx *gorm.DB,
 func WorldLikeCreate(owner, worldName string, user *users.User, tx *gorm.DB,
 	w http.ResponseWriter, r *http.Request) (interface{}, *gz.ErrMsg) {
 
-	_, count, em := (&worlds.Service{Storage: globals.Storage}).CreateWorldLike(tx, owner, worldName, user)
+	_, em := (&worlds.Service{Storage: globals.Storage}).CreateWorldLike(tx, owner, worldName, user)
 	if em != nil {
 		return nil, em
 	}
@@ -186,7 +186,6 @@ func WorldLikeCreate(owner, worldName string, user *users.User, tx *gorm.DB,
 		return nil, gz.NewErrorMessageWithBase(gz.ErrorDbSave, err)
 	}
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-	fmt.Fprint(w, count)
 	return nil, nil
 }
 
@@ -198,7 +197,7 @@ func WorldLikeCreate(owner, worldName string, user *users.User, tx *gorm.DB,
 func WorldLikeRemove(owner, worldName string, user *users.User, tx *gorm.DB,
 	w http.ResponseWriter, r *http.Request) (interface{}, *gz.ErrMsg) {
 
-	_, count, em := (&worlds.Service{Storage: globals.Storage}).RemoveWorldLike(tx, owner, worldName, user)
+	_, em := (&worlds.Service{Storage: globals.Storage}).RemoveWorldLike(tx, owner, worldName, user)
 	if em != nil {
 		return nil, em
 	}
@@ -212,7 +211,6 @@ func WorldLikeRemove(owner, worldName string, user *users.User, tx *gorm.DB,
 	}
 
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-	fmt.Fprint(w, count)
 	return nil, nil
 }
 

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -159,11 +159,11 @@ func RecomputeDownloadsAndLikes(ctx context.Context, db *gorm.DB) {
 
 	if em := (&models.Service{Storage: globals.Storage}).ComputeAllCounters(tx); em != nil {
 		tx.Rollback()
-		log.Fatal("[MIGRATION] Error while recomputing likes and downloads", em.BaseError)
+		log.Fatal("[MIGRATION] Error while recomputing model likes and downloads", em.BaseError)
 	}
 	if em := (&worlds.Service{Storage: globals.Storage}).ComputeAllCounters(tx); em != nil {
 		tx.Rollback()
-		log.Fatal("[MIGRATION] Error while recomputing likes and downloads", em.BaseError)
+		log.Fatal("[MIGRATION] Error while recomputing world likes and downloads", em.BaseError)
 	}
 
 	if err := tx.Commit().Error; err != nil {

--- a/router_models_test.go
+++ b/router_models_test.go
@@ -494,7 +494,7 @@ func TestModelLikeCreateDbMock(t *testing.T) {
 	SetupCommonMockResponses("test user")
 	ClearMockBadCommit()
 	// Make the Count DB query fail
-	mocket.Catcher.NewMock().WithQuery("SELECT count(*) FROM \"model_likes\"  WHERE").WithQueryException()
+	mocket.Catcher.NewMock().WithQuery("UPDATE \"models\" SET \"likes\"").WithExecException()
 	expErr = gz.ErrorMessage(gz.ErrorDbSave)
 	bslice, _ = gztest.AssertRouteMultipleArgs("POST", uri, nil, expErr.StatusCode, &myJWT, "text/plain; charset=utf-8", t)
 	gztest.AssertBackendErrorCode("TestModelLikeCreateDbMock", bslice, expErr.ErrCode, t)

--- a/router_models_test.go
+++ b/router_models_test.go
@@ -448,10 +448,7 @@ func TestModelLikeCreateAndDelete(t *testing.T) {
 			if expStatus != http.StatusOK && !test.ignoreErrorBody {
 				gztest.AssertBackendErrorCode(t.Name()+" "+test.method, bslice, expEm.ErrCode, t)
 			} else if expStatus == http.StatusOK {
-				// Verify that the response contains the new number of likes
-				likesCounter, err := strconv.Atoi(string(*bslice))
-				assert.NoError(t, err, "Couldn't convert the received likes counter to int.")
-				assert.Equal(t, test.expLikes, likesCounter, "Response Likes count [%d] should be equal to [%d]", likesCounter, test.expLikes)
+				// Verify that the database was updated to reflect the new number of likes
 				m := getOwnerModelFromDb(t, test.username, test.modelname)
 				assert.NotNil(t, m)
 				assert.Equal(t, test.expLikes, m.Likes, "Model's like counter [%d] should be equal to exp: [%d]", m.Likes, test.expLikes)

--- a/router_worlds_test.go
+++ b/router_worlds_test.go
@@ -10,7 +10,6 @@ import (
 	"net/url"
 	"os"
 	"path"
-	"strconv"
 	"testing"
 
 	"github.com/gazebo-web/fuel-server/bundles/models"
@@ -309,10 +308,7 @@ func TestWorldLikeCreateAndDelete(t *testing.T) {
 			if expStatus != http.StatusOK && !test.ignoreErrorBody {
 				gztest.AssertBackendErrorCode(t.Name()+" "+test.method, bslice, expEm.ErrCode, t)
 			} else if expStatus == http.StatusOK {
-				// Verify that the response contains the new number of likes
-				likesCounter, err := strconv.Atoi(string(*bslice))
-				assert.NoError(t, err, "Couldn't convert the received likes counter to int.")
-				assert.Equal(t, test.expLikes, likesCounter, "Response Likes count [%d] should be equal to [%d]", likesCounter, test.expLikes)
+				// Verify that the database was updated to reflect the new number of likes
 				w := getWorldFromDb(t, test.username, test.name)
 				assert.NotNil(t, w)
 				assert.Equal(t, test.expLikes, w.Likes, "World's like counter [%d] should be equal to exp: [%d]", w.Likes, test.expLikes)


### PR DESCRIPTION
Queries used to update like and download counts for models and worlds have been updated to use SQL expressions instead of computing and updating values inside Fuel. This change improves `like` endpoint performance and also removes the considerable cpu spike when downloading models.

One important note is that using an expression to update the value does not return the total like/download count. This value was previously returned by the endpoints and this is no longer the case. I will double check that this does not impact our app client.