### PR TITLE
Fix directory removal

### DIFF
--- a/bundles/common_resources/file_resources.go
+++ b/bundles/common_resources/file_resources.go
@@ -310,7 +310,7 @@ func CloneResourceRepo(ctx context.Context, res, clone Resource) (vcs.VCS, *gz.E
 	repo = globals.VCSRepoFactory(ctx, *clone.GetLocation())
 	// and tag it with the clone's UUID
 	if err := repo.Tag(ctx, *clone.GetUUID()); err != nil {
-		_ = os.Remove(*clone.GetLocation())
+		_ = os.RemoveAll(*clone.GetLocation())
 		return nil, gz.NewErrorMessageWithBase(gz.ErrorCreatingDir, err)
 	}
 	return repo, nil

--- a/bundles/worlds/worlds_service.go
+++ b/bundles/worlds/worlds_service.go
@@ -870,13 +870,13 @@ func (ws *Service) CloneWorld(ctx context.Context, tx *gorm.DB, swOwner,
 
 	// Zip the world and compute its size.
 	if em := ws.updateZip(ctx, repo, &clone); em != nil {
-		os.Remove(*clone.Location)
+		os.RemoveAll(*clone.Location)
 		return nil, em
 	}
 
 	// If everything went OK then create the new world in DB.
 	if err := tx.Create(&clone).Error; err != nil {
-		os.Remove(*clone.Location)
+		os.RemoveAll(*clone.Location)
 		return nil, gz.NewErrorMessageWithBase(gz.ErrorDbSave, err)
 	}
 

--- a/handler_collections.go
+++ b/handler_collections.go
@@ -188,7 +188,7 @@ func CollectionUpdate(owner, name string, user *users.User, tx *gorm.DB,
 		// first, populate files into tmp dir to avoid overriding original
 		// files in case of error.
 		tmpDir, err := os.MkdirTemp("", name)
-		defer os.Remove(tmpDir)
+		defer os.RemoveAll(tmpDir)
 		if err != nil {
 			return nil, gz.NewErrorMessageWithBase(gz.ErrorRepo, err)
 		}

--- a/handler_models_creation.go
+++ b/handler_models_creation.go
@@ -68,7 +68,7 @@ func doCreateModel(tx *gorm.DB, cb createFn, w http.ResponseWriter, r *http.Requ
 	// before writing "data" to ResponseWriter. Once you write data (not headers)
 	// into it the status code is set to 200 (OK).
 	if err := tx.Commit().Error; err != nil {
-		os.Remove(*model.Location)
+		os.RemoveAll(*model.Location)
 		return nil, gz.NewErrorMessageWithBase(gz.ErrorNoDatabase, err)
 	}
 
@@ -111,7 +111,7 @@ func modelFn(cm models.CreateModel, tx *gorm.DB, jwtUser *users.User, w http.Res
 	// move files from multipart form into new model's folder
 	_, em := populateTmpDir(r, true, modelPath)
 	if em != nil {
-		_ = os.Remove(modelPath)
+		_ = os.RemoveAll(modelPath)
 		return nil, em
 	}
 
@@ -119,7 +119,7 @@ func modelFn(cm models.CreateModel, tx *gorm.DB, jwtUser *users.User, w http.Res
 	ms := &models.Service{Storage: globals.Storage}
 	model, em := ms.CreateModel(r.Context(), tx, cm, uuidStr, modelPath, jwtUser)
 	if em != nil {
-		_ = os.Remove(modelPath)
+		_ = os.RemoveAll(modelPath)
 		return nil, em
 	}
 	return model, nil
@@ -170,7 +170,7 @@ func ModelCreate(tx *gorm.DB, w http.ResponseWriter, r *http.Request) (interface
 	// before writing "data" to ResponseWriter. Once you write data (not headers)
 	// into it the status code is set to 200 (OK).
 	if err := tx.Commit().Error; err != nil {
-		os.Remove(*model.Location)
+		os.RemoveAll(*model.Location)
 		return nil, gz.NewErrorMessageWithBase(gz.ErrorNoDatabase, err)
 	}
 
@@ -264,7 +264,7 @@ func ModelUpdate(owner, modelName string, user *users.User, tx *gorm.DB,
 		// first, populate files into tmp dir to avoid overriding model
 		// files in case of error.
 		tmpDir, err := os.MkdirTemp("", modelName)
-		defer os.Remove(tmpDir)
+		defer os.RemoveAll(tmpDir)
 		if err != nil {
 			return nil, gz.NewErrorMessageWithBase(gz.ErrorRepo, err)
 		}

--- a/handler_worlds.go
+++ b/handler_worlds.go
@@ -338,7 +338,7 @@ func doCreateWorld(tx *gorm.DB, cb createWorldFn, w http.ResponseWriter, r *http
 	// before writing "data" to ResponseWriter. Once you write data (not headers)
 	// into it the status code is set to 200 (OK).
 	if err := tx.Commit().Error; err != nil {
-		os.Remove(*world.Location)
+		os.RemoveAll(*world.Location)
 		return nil, gz.NewErrorMessageWithBase(gz.ErrorNoDatabase, err)
 	}
 
@@ -403,7 +403,7 @@ func WorldCreate(tx *gorm.DB, w http.ResponseWriter, r *http.Request) (interface
 		// move files from multipart form into new world's folder
 		_, em := populateTmpDir(r, true, worldPath)
 		if em != nil {
-			os.Remove(worldPath)
+			os.RemoveAll(worldPath)
 			return nil, em
 		}
 
@@ -411,7 +411,7 @@ func WorldCreate(tx *gorm.DB, w http.ResponseWriter, r *http.Request) (interface
 		ws := &worlds.Service{Storage: globals.Storage}
 		world, em := ws.CreateWorld(r.Context(), tx, cw, uuidStr, worldPath, jwtUser)
 		if em != nil {
-			os.Remove(worldPath)
+			os.RemoveAll(worldPath)
 			return nil, em
 		}
 		return world, nil
@@ -493,7 +493,7 @@ func WorldUpdate(owner, worldName string, user *users.User, tx *gorm.DB,
 		// first, populate files into tmp dir to avoid overriding world
 		// files in case of error.
 		tmpDir, err := os.MkdirTemp("", worldName)
-		defer os.Remove(tmpDir)
+		defer os.RemoveAll(tmpDir)
 		if err != nil {
 			return nil, gz.NewErrorMessageWithBase(gz.ErrorRepo, err)
 		}


### PR DESCRIPTION
We were using `os.Remove`, which [only removes directories if they are empty](https://pkg.go.dev/os#Remove). We need to use [os.RemoveAll](https://pkg.go.dev/os#RemoveAll). Without this fix, the disk space on the fuel server slowly increases with each model/world upload.

I also added a check for `globals.QueryCache` in models_service.go to suppress error messages if the querey cache server does not exist.  